### PR TITLE
Values of units omitted in format string are resetted to default value

### DIFF
--- a/src/DatePicker/DatePicker.php
+++ b/src/DatePicker/DatePicker.php
@@ -45,7 +45,7 @@ class DatePicker extends AbstractDateTimePicker
   {
     if (strlen($this->value) > 0)
     {
-      $date = DateTime::createFromFormat($this->format, $this->value);
+      $date = DateTime::createFromFormat($this->format.'|', $this->value);
 
       if ($date === FALSE)
       {
@@ -54,7 +54,7 @@ class DatePicker extends AbstractDateTimePicker
         return FALSE;
       }
 
-      return $date->setTime(0, 0, 0);
+      return $date;
     }
 
     return $this->value;

--- a/src/DateTimePicker/DateTimePicker.php
+++ b/src/DateTimePicker/DateTimePicker.php
@@ -45,7 +45,7 @@ class DateTimePicker extends AbstractDateTimePicker
   {
     if (strlen($this->value) > 0)
     {
-      $datetime = DateTime::createFromFormat($this->format, $this->value);
+      $datetime = DateTime::createFromFormat($this->format.'|', $this->value);
 
       if ($datetime === FALSE)
       {

--- a/src/TbDatePicker/TbDatePicker.php
+++ b/src/TbDatePicker/TbDatePicker.php
@@ -38,7 +38,7 @@ class TbDatePicker extends AbstractDateTimePicker
   {
     if (strlen($this->value) > 0)
     {
-      $date = DateTime::createFromFormat($this->format, $this->value);
+      $date = DateTime::createFromFormat($this->format.'|', $this->value);
 
       if ($date === FALSE)
       {
@@ -47,7 +47,7 @@ class TbDatePicker extends AbstractDateTimePicker
         return FALSE;
       }
 
-      return $date->setTime(0, 0, 0);
+      return $date;
     }
 
     return $this->value;

--- a/src/TbDateTimePicker/TbDateTimePicker.php
+++ b/src/TbDateTimePicker/TbDateTimePicker.php
@@ -38,7 +38,7 @@ class TbDateTimePicker extends AbstractDateTimePicker
   {
     if (strlen($this->value) > 0)
     {
-      $datetime = DateTime::createFromFormat($this->format, $this->value);
+      $datetime = DateTime::createFromFormat($this->format.'|', $this->value);
 
       if ($datetime === FALSE)
       {


### PR DESCRIPTION
Values of units omitted in format string are resetted to default value instead of current datetime.
Resolves error when DatePicker is used as month picker (format is set to m. Y) and today is 30. 3. 2017 and submitted value is 02. 2017 (getValue returns 2. 3. 2017, but correct value is 1. 2. 2017)