### PR TITLE
FIX compile error

### DIFF
--- a/src/DateTimePicker/DateTimePicker.php
+++ b/src/DateTimePicker/DateTimePicker.php
@@ -30,7 +30,7 @@ class DateTimePicker extends AbstractDateTimePicker
   private $readonly = TRUE;
 
   /** @return mixed */
-  public function getValue()
+  public function getValue(): mixed
   {
     if (strlen($this->value) > 0)
     {


### PR DESCRIPTION
  Declaration of RadekDostal\NetteComponents\DateTimePicker\DatePicker::getValue() must be compatible with Nette\Forms\Controls\TextBase::getValue(): mixed