### PR TITLE
FIX Compile Error

### DIFF
--- a/src/DatePicker/DatePicker.php
+++ b/src/DatePicker/DatePicker.php
@@ -30,7 +30,7 @@ class DatePicker extends AbstractDateTimePicker
   private $readonly = TRUE;
 
   /** @return mixed */
-  public function getValue()
+  public function getValue(): mixed
   {
     if (strlen($this->value) > 0)
     {


### PR DESCRIPTION
  Declaration of RadekDostal\NetteComponents\DateTimePicker\DatePicker::getValue() must be compatible with Nette\Forms\Controls\TextBase::getValue(): mixed